### PR TITLE
feat: Implement date range filtering for staff performance reports

### DIFF
--- a/counters/templates/counters/reports.html
+++ b/counters/templates/counters/reports.html
@@ -70,14 +70,21 @@
                 </select>
             </div>
 
-            <div>
-                <label class="block text-xs font-semibold text-slate-600 mb-1">
-                    Date
-                </label>
-                <input type="date" name="date"
-                    value="{{ selected_date }}"
-                    class="border border-slate-200 rounded px-3 py-2 text-sm">
+            <div class="flex gap-4">
+                <div>
+                    <label class="block text-xs font-semibold text-slate-6500 mb-1">From</label>
+                    <input type="date" name="start_date"
+                        value="{{ start_date }}"
+                        class="border border-slate-200 rounded px-3 py-2 text-sm">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-6500 mb-1">To</label>
+                    <input type="date" name="end_date"
+                        value="{{ end_date }}"
+                        class="border border-slate-200 rounded px-3 py-2 text-sm">
+                </div>
             </div>
+
              <div>
                 <label class="block text-xs font-semibold text-slate-600 mb-1">
                     Rows
@@ -95,12 +102,13 @@
                 Apply Filters
             </button>
 
-            {% if selected_client_type or selected_service or selected_date %}
+            {% if selected_client_type or selected_service or start_date or end_date %}
                 <a href="{% url 'counter-reports' %}"
-                   class="bg-slate-200 text-slate-700 px-4 py-2 rounded text-sm hover:bg-slate-300 transition">
+                class="bg-slate-200 text-slate-700 px-4 py-2 rounded text-sm hover:bg-slate-300 transition">
                     Clear Filters
                 </a>
             {% endif %}
+            
         </form>
     </div>
 

--- a/counters/views.py
+++ b/counters/views.py
@@ -234,7 +234,8 @@ def counter_reports(request):
 
     client_type = request.GET.get("client_type", "")
     service_id = request.GET.get("service", "")
-    date_filter = request.GET.get("date", "")
+    start_date = request.GET.get("start_date", "")
+    end_date = request.GET.get("end_date", "")
 
     if client_type:
         tickets = tickets.filter(client_type=client_type)
@@ -242,12 +243,12 @@ def counter_reports(request):
     if service_id:
         tickets = tickets.filter(service__id=service_id)
 
-    if date_filter:
-        try:
-            filter_date = datetime.strptime(date_filter, "%Y-%m-%d").date()
-            tickets = tickets.filter(served_at__date=filter_date)
-        except ValueError:
-            pass
+    if start_date and end_date:
+        tickets = tickets.filter(served_at__date__range=[start_date, end_date])
+    elif start_date:
+        tickets = tickets.filter(served_at__date__gte=start_date)
+    elif end_date:
+        tickets = tickets.filter(served_at__date__lte=end_date)
 
     tickets_with_time = tickets.filter(
         called_at__isnull=False,
@@ -306,7 +307,8 @@ def counter_reports(request):
         "client_types": Ticket.ClientType.choices,
         "selected_client_type": client_type,
         "selected_service": service_id,
-        "selected_date": date_filter,
+        "start_date": start_date,
+        "end_date": end_date,
         "average_aht": average_aht,
     }
 


### PR DESCRIPTION
📝 Description
This PR improves the staff reporting usability by replacing the single-date filter with a flexible Date Range system. It also fixes a regression where the "Clear Filters" button was hidden due to the change in context variable names.

🚀 Changes Made
1. Range-Based Querying
View Logic: Updated counter_reports in views.py to capture start_date and end_date from GET parameters.

Django Lookups: Implemented __date__range for inclusive filtering when both dates are provided, and __gte/__lte for open-ended ranges.

Performance: Retained select_related to ensure that even when fetching large date ranges, the database query count remains low (O(1) instead of O(n)).

2. UI/UX Refinement
Template Update: Refactored reports.html to include a "From" and "To" date picker layout using Tailwind CSS for a cleaner, responsive look.

Filter Persistence: Updated the form to retain the selected start_date and end_date after the page reloads, allowing users to see their current active filter.

Reset Button Fix: Updated the conditional {% if %} logic in the template to check for the new date variables, ensuring the "Clear Filters" button appears correctly when any filter is active.

🧪 Testing & Validation
[x] Date Range: Verified that selecting a range (e.g., Monday to Friday) correctly aggregates the total tickets and AHT for that specific window.

[x] Single Date Entry: Verified that filling only "From" or only "To" still filters the results correctly (Greater than or Less than).

[x] UI Reset: Confirmed "Clear Filters" redirects to the base report URL, clearing all inputs and recalculating totals.

[x] AHT Calculation: Confirmed the Average Handling Time updates dynamically based on the filtered subset of tickets.